### PR TITLE
feat: add configuration loading from JSON and TOML files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.3
 require github.com/gofiber/fiber/v2 v2.52.6
 
 require (
+	github.com/BurntSushi/toml v1.4.0
 	github.com/andybalholm/brotli v1.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
+github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/gofiber/fiber/v2 v2.52.6 h1:Rfp+ILPiYSvvVuIPvxrBns+HJp8qGLDnLJawAu27XVI=

--- a/hst/config.go
+++ b/hst/config.go
@@ -1,6 +1,24 @@
 // Package hst contains shared types useful to third party programs wishing to integrate with hizla.
 package hst
 
+import (
+	"errors"
+	"os"
+)
+
+var (
+	ErrUnsetAddress = errors.New("listen address not present in environment")
+)
+
 type ServeAPI struct {
 	Address string `json:"address"`
+}
+
+func (s *ServeAPI) FromEnviron() error {
+	if addr := os.Getenv("HIZLA_API_LISTEN_ADDRESS"); addr != "" {
+		s.Address = addr
+	} else {
+		return ErrUnsetAddress
+	}
+	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+
+	"github.com/BurntSushi/toml"
+)
+
+type Config interface {
+	FromEnviron() error
+}
+
+const (
+	FromEnviron = iota
+	FromJSON
+	FromTOML
+)
+
+var ErrInvalidWhence = errors.New("invalid whence")
+
+// Load populates config based on whence,
+// if whence is a serialisation format, it is decoded from r.
+func Load(config Config, whence int, r io.Reader) error {
+	switch whence {
+	case FromEnviron:
+		return config.FromEnviron()
+
+	case FromJSON:
+		return json.NewDecoder(r).Decode(config)
+
+	case FromTOML:
+		_, err := toml.NewDecoder(r).Decode(config)
+		return err
+
+	default:
+		return ErrInvalidWhence
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,43 @@
+package config_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/hizla/hizla/internal/config"
+)
+
+type testConfig string
+
+func (t *testConfig) FromEnviron() error {
+	return nil
+}
+
+func TestLoad(t *testing.T) {
+	testCases := []struct {
+		name    string
+		whence  int
+		data    string
+		want    any
+		wantErr bool
+	}{
+		{"environ", config.FromEnviron, "", new(testConfig), false},
+		{"json", config.FromJSON, `""`, new(testConfig), false},
+		{"toml", config.FromTOML, "", new(testConfig), true},
+		{"invalid", -1, "", nil, true},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := new(testConfig)
+			if err := config.Load(got, tc.whence, strings.NewReader(tc.data)); (err != nil) != tc.wantErr {
+				t.Errorf("Load() error = %v, wantErr %v", err, tc.wantErr)
+				return
+			}
+			if !tc.wantErr && !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("Load() c = %#v; want %#v", got, tc.want)
+				return
+			}
+		})
+	}
+}

--- a/package.nix
+++ b/package.nix
@@ -13,7 +13,7 @@ buildGoModule rec {
     filter = path: type: !(type != "directory" && lib.hasSuffix ".nix" path);
   };
 
-  vendorHash = "sha256-AThrcTXGfcweY1CJ2KRGDi/v0uyxaQr7JWi998ZE41M=";
+  vendorHash = "sha256-jeGo/Y+evhybU0ftpIUfJ88OmGTtwaJi0I3nAVNlHis=";
 
   ldflags = lib.attrsets.foldlAttrs (
     ldflags: name: value:


### PR DESCRIPTION
- Introduced new flags `-j` for JSON config and `-t` for TOML config.
- Default configuration is loaded from environment variables if no config file is specified.
- Refactored configuration loading logic into an internal `config` package.